### PR TITLE
rescue ECONNRESET

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,5 @@
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
  - Dependency on logstash-core update to 2.0
  - Update to allow semicolons (or not, e.g. Zabbix 2.0). #6 (davmrtl)
+ - Update to prevent Logstash from crashing when the Zabbix server becomes unavailable while the plugin is sending data. 
+   Ref: https://github.com/logstash-plugins/logstash-output-zabbix/pull/9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,5 +3,4 @@
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
  - Dependency on logstash-core update to 2.0
  - Update to allow semicolons (or not, e.g. Zabbix 2.0). #6 (davmrtl)
- - Update to prevent Logstash from crashing when the Zabbix server becomes unavailable while the plugin is sending data. 
-   Ref: https://github.com/logstash-plugins/logstash-output-zabbix/pull/9
+ - Update to prevent Logstash from crashing when the Zabbix server becomes unavailable while the plugin is sending data. #9 (dkanbier) 

--- a/lib/logstash/outputs/zabbix.rb
+++ b/lib/logstash/outputs/zabbix.rb
@@ -208,7 +208,7 @@ class LogStash::Outputs::Zabbix < LogStash::Outputs::Base
         # Did the message get received by Zabbix?
         response_check(event, resp)
       end
-    rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
+    rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Errno::ECONNRESET
       @logger.error("Connection error.  Unable to connect to Zabbix server",
         :server => @zabbix_server_host,
         :port => @zabbix_server_port.to_s


### PR DESCRIPTION
This change prevents Logstash from crashing when using the logstash-output-zabbix plugin and the receiving Zabbix server becomes unreachable during a transmit. 

Without this fix Logstash will crash when you stop the receiving zabbix-server while a transaction to this server was in progress:

```
-bash-4.2$ /opt/logstash/bin/logstash agent -f /etc/logstash/conf.d/logstash-indexer.conf -l /var/log/logstash/logstash.log
Sending logstash logs to /var/log/logstash/logstash.log.

Errno::ECONNRESET: Connection reset by peer - Connection reset by peer
            read at org/jruby/RubyIO.java:3073
        tcp_send at /opt/logstash/vendor/bundle/jruby/1.9/gems/logstash-output-zabbix-1.0.0/lib/logstash/outputs/zabbix.rb:203
            open at org/jruby/RubyIO.java:1183
        tcp_send at /opt/logstash/vendor/bundle/jruby/1.9/gems/logstash-output-zabbix-1.0.0/lib/logstash/outputs/zabbix.rb:200
  send_to_zabbix at /opt/logstash/vendor/bundle/jruby/1.9/gems/logstash-output-zabbix-1.0.0/lib/logstash/outputs/zabbix.rb:223
         timeout at org/jruby/ext/timeout/Timeout.java:126
  send_to_zabbix at /opt/logstash/vendor/bundle/jruby/1.9/gems/logstash-output-zabbix-1.0.0/lib/logstash/outputs/zabbix.rb:222
         receive at /opt/logstash/vendor/bundle/jruby/1.9/gems/logstash-output-zabbix-1.0.0/lib/logstash/outputs/zabbix.rb:239
          handle at /opt/logstash/vendor/bundle/jruby/1.9/gems/logstash-core-1.5.4-java/lib/logstash/outputs/base.rb:88
     output_func at (eval):780
    outputworker at /opt/logstash/vendor/bundle/jruby/1.9/gems/logstash-core-1.5.4-java/lib/logstash/pipeline.rb:244
   start_outputs at /opt/logstash/vendor/bundle/jruby/1.9/gems/logstash-core-1.5.4-java/lib/logstash/pipeline.rb:166
```
